### PR TITLE
error handling and accessors for nbt

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,29 @@
+use std::io;
+use std::convert::From;
+use std::string;
+use byteorder;
+
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    BadEncoding(string::FromUtf8Error),
+    UnexpectedEOF,
+    UnexpectedTag(u8),
+}
+
+impl From<byteorder::Error> for Error {
+    fn from(err: byteorder::Error) -> Error {
+        match err {
+            byteorder::Error::UnexpectedEOF => Error::UnexpectedEOF,
+            byteorder::Error::Io(e) => From::from(e),
+        }
+    }
+}
+
+impl From<string::FromUtf8Error> for Error {
+    fn from(err: string::FromUtf8Error) -> Error { Error::BadEncoding(err) }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error { Error::Io(err) }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,10 @@ pub enum Error {
     Io(io::Error),
     BadEncoding(string::FromUtf8Error),
     UnexpectedEOF,
-    UnexpectedTag(u8),
+    UnexpectedTag(u8), // when finding an unknown tag type while parsing
+    UnexpectedType, // when trying to access data of the wrong type on a tag
+    InvalidKey(String), // when trying to get a bad key
+    InvalidIndex(usize), // when trying to get a bad index
 }
 
 impl From<byteorder::Error> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ extern crate flate2;
 extern crate byteorder;
 
 pub use error::Error;
-pub use nbt::Tag;
+pub use nbt::{Tag, Taglike};
 
 pub mod error;
 pub mod nbt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 extern crate flate2;
 extern crate byteorder;
 
+pub use error::Error;
 pub use nbt::Tag;
 
+pub mod error;
 pub mod nbt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![allow(dead_code)]
-#![allow(unused_imports)]
-
 extern crate flate2;
 extern crate byteorder;
 

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -11,7 +11,7 @@ pub enum Tag {
     TagLong(i64),
     TagFloat(f32),
     TagDouble(f64),
-    TagByteArray(Vec<i8>),
+    TagByteArray(Vec<u8>),
     TagString(String),
     TagList(Vec<Tag>),
     TagCompound(HashMap<String, Tag>),
@@ -19,14 +19,14 @@ pub enum Tag {
 
 impl Tag {
     pub fn parse_file<R>(r: &mut R) -> (String, Tag) where R: Read {
-        let ty = r.read_i8().unwrap();
-        let name = read_string(r);
+        let ty = r.read_u8().unwrap();
+        let name = Tag::read_string(r);
         let tag = Tag::parse_tag(r, Some(ty));
         (name, tag)
     }
 
-    pub fn parse_tag<R>(r: &mut R, tag_type: Option<i8>) -> Tag where R: Read {
-        match tag_type.unwrap_or_else(|| r.read_i8().unwrap()) {
+    pub fn parse_tag<R>(r: &mut R, tag_type: Option<u8>) -> Tag where R: Read {
+        match tag_type.unwrap_or_else(|| r.read_u8().unwrap()) {
             0 => Tag::TagEnd,
             1 => Tag::TagByte(r.read_i8().unwrap()),
             2 => Tag::TagShort(r.read_i16::<BigEndian>().unwrap()),
@@ -35,24 +35,21 @@ impl Tag {
             5 => Tag::TagFloat(r.read_f32::<BigEndian>().unwrap()),
             6 => Tag::TagDouble(r.read_f64::<BigEndian>().unwrap()),
             7 => { // TAG_Byte_Array 
-                let len: i32 = r.read_i32::<BigEndian>().unwrap();
-                let mut v: Vec<i8> = Vec::with_capacity(len as usize);
-                for _ in 0..len {
-                    let b: i8 = r.read_i8().unwrap();
-                    v.push(b)
-                }
-                Tag::TagByteArray(v)
+                let len = r.read_u32::<BigEndian>().unwrap();
+                let mut buf = vec![0; len as usize];
+                r.read_exact(&mut buf).unwrap();
+                Tag::TagByteArray(buf)
             }
             8 => { // TAG_String
-                let s: String = read_string(r);
+                let s = Tag::read_string(r);
                 Tag::TagString(s)
             }
             9 => { // TAG_List
-                let ty: i8 = r.read_i8().unwrap();
-                let len: i32 = r.read_i32::<BigEndian>().unwrap();
-                let mut v: Vec<Tag> = Vec::with_capacity(len as usize);
+                let ty = r.read_u8().unwrap();
+                let len = r.read_u32::<BigEndian>().unwrap();
+                let mut v = Vec::with_capacity(len as usize);
                 for _ in 0..len {
-                    let t: Tag = Tag::parse_tag(r, Some(ty));
+                    let t = Tag::parse_tag(r, Some(ty));
                     v.push(t)
                 }
                 Tag::TagList(v)
@@ -61,11 +58,11 @@ impl Tag {
             10 => { // TAG_Compound
                 let mut v = HashMap::new();
                 loop {
-                    let ty = r.read_i8().unwrap();
+                    let ty = r.read_u8().unwrap();
                     if ty == 0 {
                         break;
                     }
-                    let name = read_string(r);
+                    let name = Tag::read_string(r);
                     let value = Tag::parse_tag(r, Some(ty));
                     v.insert(name, value);
                 }
@@ -73,6 +70,13 @@ impl Tag {
             }
             x => panic!(">>> Unexpected tag type {:?}", x)
         }
+    }
+
+    fn read_string<R>(r: &mut R) -> String where R: Read {
+        let len = r.read_u16::<BigEndian>().unwrap();
+        let mut buf = vec![0; len as usize];
+        r.read_exact(&mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
     }
 
     pub fn get_name(&self) -> &'static str {
@@ -92,10 +96,8 @@ impl Tag {
     }
 
     pub fn pretty_print(&self, indent: usize, name: Option<&String>) {
-        let name_s = match name {
-            Some(ref s) => format!("(\"{}\")", s),
-            None => "".to_owned()
-        };
+        let name_s = name.map(|s| format!("9\"{}\")", s)).unwrap_or("".to_string());
+
         match self {
             &Tag::TagCompound(ref v) => { println!("{1:0$}{2}{3} : {4} entries\n{1:0$}{{", indent,"", self.get_name(), name_s, v.len()); 
                 for (name, val) in v.iter() {
@@ -108,7 +110,9 @@ impl Tag {
                 let ex = data.get(0).unwrap_or(&end);
                 println!("{1:0$}{2}{3} : {4} entries of type {5}\n{1:0$}{{",
                          indent,"", self.get_name(), name_s, data.len(), ex.get_name());
-                for item in data.iter() {item.pretty_print(indent+4, None); }
+                for item in data.iter() {
+                    item.pretty_print(indent + 4, None);
+                }
                 println!("{1:0$}}}", indent, "");
             }
             &Tag::TagString(ref s) => { println!("{1:0$}{2}{3} : {4}", indent, "", self.get_name(), name_s, s) }
@@ -119,26 +123,9 @@ impl Tag {
             &Tag::TagInt(d) => { println!("{1:0$}{2}{3} : {4}", indent, "", self.get_name(), name_s, d); }
             &Tag::TagShort(d) => { println!("{1:0$}{2}{3} : {4}", indent, "", self.get_name(), name_s, d); }
             &Tag::TagByte(d) => { println!("{1:0$}{2}{3} : {4}", indent, "", self.get_name(), name_s, d); }
-            _ => println!("?")
+            &Tag::TagEnd => { println!("{1:0$}{2}{3}", indent, "", self.get_name(), name_s); }
         }
     }
-}
-
-#[derive(Debug, PartialEq)]
-pub struct NamedTag {
-    pub tag: Tag,
-    pub name: String
-}
-
-fn read_string<R>(r: &mut R) -> String
-where R: Read {
-    let len: i16 = r.read_i16::<BigEndian>().unwrap();
-    let mut s2: Vec<u8> = Vec::new();
-    for b in r.take(len as u64).bytes() {
-        let b: u8 = b.unwrap();
-        if b > 0 { s2.push(b) }
-    }
-    String::from_utf8(s2).unwrap()
 }
 
 #[cfg(test)]
@@ -163,32 +150,32 @@ mod test {
 
         let level_dat = fs::File::open("level.dat").unwrap();
 
-        let mut decoder: GzDecoder<fs::File> = GzDecoder::new(level_dat).unwrap();
+        let mut decoder = GzDecoder::new(level_dat).unwrap();
         let (_, tag) = Tag::parse_file(&mut decoder);
         tag.pretty_print(0, None);
     }
 
     #[test]
     fn test_tag_byte() {
-        let data: Vec<u8> = vec!(1, 0, 5, 'h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8, 69);
+        let data = vec!(1, 0, 5, 'h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8, 69);
         test_tag(data, "hello", Tag::TagByte(69));
     }
 
     #[test]
     fn test_tag_byte_array() {
-        let data: Vec<u8> = vec!(7, 0, 5, 'h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8, 0, 0, 0, 3, 69, 250, 123);
-        test_tag(data, "hello", Tag::TagByteArray(vec![69, -6, 123]));
+        let data = vec!(7, 0, 5, 'h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8, 0, 0, 0, 3, 69, 250, 123);
+        test_tag(data, "hello", Tag::TagByteArray(vec![69, 250, 123]));
     }
 
     #[test]
     fn test_tag_string() {
-        let data: Vec<u8> = vec!(8, 0, 5, 'h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8, 0, 3, 'c' as u8, 'a' as u8, 't' as u8);
+        let data = vec!(8, 0, 5, 'h' as u8, 'e' as u8, 'l' as u8, 'l' as u8, 'o' as u8, 0, 3, 'c' as u8, 'a' as u8, 't' as u8);
         test_tag(data, "hello", Tag::TagString("cat".to_string()));
     }
 
     #[test]
     fn test_tag_list() {
-        let data: Vec<u8> = vec!(9, 0, 2, 'h' as u8, 'i' as u8, 1, 0, 0, 0, 3, 1, 2, 3);
+        let data = vec!(9, 0, 2, 'h' as u8, 'i' as u8, 1, 0, 0, 0, 3, 1, 2, 3);
         test_tag(data, "hi", Tag::TagList(vec![Tag::TagByte(1), Tag::TagByte(2), Tag::TagByte(3)]));
     }
 }

--- a/src/nbt.rs
+++ b/src/nbt.rs
@@ -1,35 +1,8 @@
 use std::io::Read;
-use std::io;
 use std::collections::HashMap;
-use std::string;
-use std::convert::From;
 use byteorder::{ReadBytesExt, BigEndian};
-use byteorder;
 
-#[derive(Debug)]
-pub enum Error {
-    Io(io::Error),
-    BadEncoding(string::FromUtf8Error),
-    UnexpectedEOF,
-    UnexpectedTag(u8),
-}
-
-impl From<byteorder::Error> for Error {
-    fn from(err: byteorder::Error) -> Error {
-        match err {
-            byteorder::Error::UnexpectedEOF => Error::UnexpectedEOF,
-            byteorder::Error::Io(e) => From::from(e),
-        }
-    }
-}
-
-impl From<string::FromUtf8Error> for Error {
-    fn from(err: string::FromUtf8Error) -> Error { Error::BadEncoding(err) }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Error { Error::Io(err) }
-}
+use super::error::Error;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Tag {


### PR DESCRIPTION
Simple thing: all functions that can fail now return a Result instead of panicing.

Other thing: Tags now have a bunch of accessor functions (in the Taglike trait). Results containing tags also have these accessors, so getting at deeply nested data with the correct type is easy:

```rust
let thundering = try!(Tag::parse_file(...).key("Data").key("thundering").as_i8());
```

Unfortunately I can't implement Index for this (noooo!) because rust doesn't let indexing consume the thing you index, which I need because `Result::and_then` consumes the result.